### PR TITLE
fix(initdb.d): Do not rely on using initdb.d to enable extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,4 @@ RUN apt-get install -y --no-install-recommends ./pgvectors.deb && \
 # Change to the uid of postgres (26)
 USER 26
 
-# From https://stackoverflow.com/a/42508925
-# Note that this way of enabling the plugin only works on database init
-# We should investigate alternative ways of enabling it that will always work
-COPY install-pgvectors.sql /docker-entrypoint-initdb.d/
+CMD ["postgres", "-c", "shared_preload_libraries=vectors.so"]

--- a/README.md
+++ b/README.md
@@ -6,20 +6,7 @@ My custom Postgres Docker images with extensions that I need. Based on Cloudnati
 
 ### [pgvecto.rs](https://github.com/tensorchord/pgvecto.rs)
 
-> [!IMPORTANT]
-> If you are using this image on an existing database, the postgres configuration needs to be
-> altered to enable the extension. You can do this by setting shared_preload_libraries in your Cluster spec:
-> ```yaml
-> apiVersion: postgresql.cnpg.io/v1
-> kind: Cluster
-> spec:
->   (...)
->   postgresql:
->     shared_preload_libraries:
->       - "vectors.so"
->   ```
-
-According to pgvecto.rs documentation we also need to run the following on each database that should have vectors enabled.
+According to pgvecto.rs documentation we need to run the following on each database that will be using the vector extension.
 
 ```sql
 DROP EXTENSION IF EXISTS vectors;

--- a/install-pgvectors.sql
+++ b/install-pgvectors.sql
@@ -1,1 +1,0 @@
-ALTER SYSTEM SET shared_preload_libraries = "vectors.so"


### PR DESCRIPTION
With this fix extension will be available for both new and existing databases.